### PR TITLE
Allow stream to be an IO object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# HEAD
+
+### Allow `stream` to be an IO object
+
+In addition to passing `stream` as a String, now you can also pass in any IO
+object, which will be streamed to the standard input. This is suitable for
+larger files, where we want to avoid having to load the whole file into
+memory.
+
 # 0.0.2
 
 ### Add `fdpass` to validated options

--- a/spec/clam_scan_spec.rb
+++ b/spec/clam_scan_spec.rb
@@ -63,12 +63,20 @@ describe ClamScan do
   end
 
   context :streaming do
-    it 'detects safety from streamed data' do
+    it 'detects safety from streamed string' do
       expect(scan(stream: File.read(safe_path)).safe?).to be_truthy
     end
 
-    it 'detects a virus from streamed data' do
+    it 'detects safety from streamed IO' do
+      expect(scan(stream: File.open(safe_path)).safe?).to be_truthy
+    end
+
+    it 'detects a virus from streamed string' do
       expect(scan(stream: File.read(eicar_path)).virus?).to be_truthy
+    end
+
+    it 'detects a virus from streamed IO' do
+      expect(scan(stream: File.open(eicar_path)).virus?).to be_truthy
     end
   end
 


### PR DESCRIPTION
This change adds the ability to pass an IO object as `:stream`, and its contents will be streamed to the standard input. This is suitable for larger files where want to avoid loading the whole file into memory.

I somehow couldn't get tests to work on MacOS and ClamAV 0.99.2, many of them were failing for me before any of these changes.